### PR TITLE
support for any term

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,14 @@ Foil is a cache that compiles key-values into Erlang modules. Key-values can be 
 
 ## Examples
 
+
+```
+erl -pa  _build/compile/lib/*/ebin
+Erlang/OTP 20 [erts-9.3] [source] [64-bit] [smp:16:16] [ds:16:16:10] [async-threads:10] [kernel-poll:false]
+
+Eshell V9.3  (abort with ^G)
+```
+
 ```erlang
 1> foil_app:start().
 {ok, [metal, foil]}
@@ -39,7 +47,42 @@ ok
 
 8> foil:lookup(test, key3).
 {error, key_not_found}
+
+9> foil:new(complex_test).
+ok
+
+10> Pid = spawn(timer, sleep, [100000]).      
+<0.70.0>
+
+11> foil:insert(complex_test, pid, Pid).
+ok
+
+12> Ref = make_ref().
+#Ref<0.2665151396.1923612679.12103>
+
+13> foil:insert(complex_test, ref, Ref).
+ok
+
+14> ComplexTerm = [Ref, {my_sleepy_pid, Pid}, [1,2,9.5], [{one, "one"}, {two, "two"}, {pid_again, Pid}]].
+
+15> foil:insert(complex_test, term, ComplexTerm).
+ok
+
+16> foil:load(complex_test).
+ok
+
+17>{ok, Pid} = complex_test_foil:lookup(pid).
+18>{current_function,{timer,sleep,1}} = process_info(Pid, current_function).
+
+19>{ok, Ref} = complex_test_foil:lookup(ref).
+
+20>{ok, ComplexTerm} = complex_test_foil:lookup(term).
+
+21>foil:delete(complex_test).
+ok
+
 ```
+
 
 ## Tests
 

--- a/src/foil_compiler.erl
+++ b/src/foil_compiler.erl
@@ -61,4 +61,11 @@ to_syntax(Integer) when is_integer(Integer) ->
 to_syntax(List) when is_list(List) ->
     erl_syntax:list([to_syntax(X) || X <- List]);
 to_syntax(Tuple) when is_tuple(Tuple) ->
-    erl_syntax:tuple([to_syntax(X) || X <- tuple_to_list(Tuple)]).
+    erl_syntax:tuple([to_syntax(X) || X <- tuple_to_list(Tuple)]);
+to_syntax(AnyTerm) ->
+    SerializedTerm = term_to_binary(AnyTerm),
+    SerializedTermStringSyntax = erl_syntax:string(binary_to_list(SerializedTerm)),
+    SerializedTermBinarySyntax = erl_syntax:binary([erl_syntax:binary_field(SerializedTermStringSyntax)]),
+    erl_syntax:application(
+        erl_syntax:atom(binary_to_term),
+        [SerializedTermBinarySyntax]).

--- a/src/foil_compiler.erl
+++ b/src/foil_compiler.erl
@@ -62,8 +62,10 @@ to_syntax(List) when is_list(List) ->
     erl_syntax:list([to_syntax(X) || X <- List]);
 to_syntax(ComplexTerm) ->
     SerializedTerm = term_to_binary(ComplexTerm),
-    SerializedTermStringSyntax = erl_syntax:string(binary_to_list(SerializedTerm)),
-    SerializedTermBinarySyntax = erl_syntax:binary([erl_syntax:binary_field(SerializedTermStringSyntax)]),
+    SerializedTermStringSyntax =
+      erl_syntax:string(binary_to_list(SerializedTerm)),
+    SerializedTermBinarySyntax =
+      erl_syntax:binary([erl_syntax:binary_field(SerializedTermStringSyntax)]),
     erl_syntax:application(
         erl_syntax:atom(binary_to_term),
         [SerializedTermBinarySyntax]).

--- a/src/foil_compiler.erl
+++ b/src/foil_compiler.erl
@@ -58,6 +58,8 @@ to_syntax(Float) when is_float(Float) ->
     erl_syntax:float(Float);
 to_syntax(Integer) when is_integer(Integer) ->
     erl_syntax:integer(Integer);
+to_syntax(List) when is_list(List) ->
+    erl_syntax:list([to_syntax(X) || X <- List]);
 to_syntax(ComplexTerm) ->
     SerializedTerm = term_to_binary(ComplexTerm),
     SerializedTermStringSyntax = erl_syntax:string(binary_to_list(SerializedTerm)),

--- a/src/foil_compiler.erl
+++ b/src/foil_compiler.erl
@@ -60,6 +60,8 @@ to_syntax(Integer) when is_integer(Integer) ->
     erl_syntax:integer(Integer);
 to_syntax(List) when is_list(List) ->
     erl_syntax:list([to_syntax(X) || X <- List]);
+to_syntax(Tuple) when is_tuple(Tuple) ->
+    erl_syntax:tuple([to_syntax(X) || X <- tuple_to_list(Tuple)]);
 to_syntax(ComplexTerm) ->
     SerializedTerm = term_to_binary(ComplexTerm),
     SerializedTermStringSyntax =

--- a/src/foil_compiler.erl
+++ b/src/foil_compiler.erl
@@ -62,6 +62,8 @@ to_syntax(List) when is_list(List) ->
     erl_syntax:list([to_syntax(X) || X <- List]);
 to_syntax(Tuple) when is_tuple(Tuple) ->
     erl_syntax:tuple([to_syntax(X) || X <- tuple_to_list(Tuple)]);
+to_syntax(Ref) when is_reference(Ref) ->
+    erl_syntax:integer(Ref);
 to_syntax(ComplexTerm) ->
     SerializedTerm = term_to_binary(ComplexTerm),
     SerializedTermStringSyntax =

--- a/src/foil_compiler.erl
+++ b/src/foil_compiler.erl
@@ -58,12 +58,8 @@ to_syntax(Float) when is_float(Float) ->
     erl_syntax:float(Float);
 to_syntax(Integer) when is_integer(Integer) ->
     erl_syntax:integer(Integer);
-to_syntax(List) when is_list(List) ->
-    erl_syntax:list([to_syntax(X) || X <- List]);
-to_syntax(Tuple) when is_tuple(Tuple) ->
-    erl_syntax:tuple([to_syntax(X) || X <- tuple_to_list(Tuple)]);
-to_syntax(AnyTerm) ->
-    SerializedTerm = term_to_binary(AnyTerm),
+to_syntax(ComplexTerm) ->
+    SerializedTerm = term_to_binary(ComplexTerm),
     SerializedTermStringSyntax = erl_syntax:string(binary_to_list(SerializedTerm)),
     SerializedTermBinarySyntax = erl_syntax:binary([erl_syntax:binary_field(SerializedTermStringSyntax)]),
     erl_syntax:application(

--- a/test/foil_tests.erl
+++ b/test/foil_tests.erl
@@ -88,7 +88,8 @@ foil_any_term_test()->
 
     {ok, TestPid} = any_term_test_foil:lookup(pid),
     {ok, TestPid} = foil:lookup(Table, pid),
-    {current_function, {timer, sleep, 1}} = process_info(TestPid, current_function),
+    {current_function, {timer, sleep, 1}} =
+      process_info(TestPid, current_function),
 
     {ok, ComplexListTerm} = any_term_test_foil:lookup(list),
     {ok, ComplexListTerm} = foil:lookup(Table, list),

--- a/test/foil_tests.erl
+++ b/test/foil_tests.erl
@@ -58,9 +58,10 @@ foil_any_term_test()->
     TestRef2 = make_ref(),
     RefList = [TestRef1, TestRef2],
 
-    ComplexListTerm = [make_ref(), make_ref(), {1,2,moo, {make_ref(), TestPid}}, "Hello"],
+    ComplexListTerm =
+        [make_ref(), make_ref(), {1, 2, moo, {make_ref(), TestPid}}, "Hello"],
     ComplexTupleTerm1 = {1, {ref1, make_ref()}, [TestPid]},
-    ComplexTupleTerm2 = {moo, boo, make_ref(), {1,2,3}, [5,6,7]},
+    ComplexTupleTerm2 = {moo, boo, make_ref(), {1, 2, 3}, [5, 6, 7]},
     PropList = [{ref1, make_ref()}, {ref2, make_ref()}, {ref3, make_ref()}],
 
     ok = foil:insert(Table, ref1, TestRef1),
@@ -79,15 +80,15 @@ foil_any_term_test()->
     {ok, TestRef1} = any_term_test_foil:lookup(ref1),
     {ok, TestRef1} = foil:lookup(Table, ref1),
 
-%%    {ok, ref2} = any_term_test_foil:lookup(list_to_binary(term_to_binary(TestRef2))),
-%%    {ok, ref2} = foil:lookup(Table, TestRef2),
+    {ok, TestRef2} = any_term_test_foil:lookup(ref2),
+    {ok, TestRef2} = foil:lookup(Table, ref2),
 
     {ok, RefList} = any_term_test_foil:lookup(ref_list),
     {ok, RefList} = foil:lookup(Table, ref_list),
 
     {ok, TestPid} = any_term_test_foil:lookup(pid),
     {ok, TestPid} = foil:lookup(Table, pid),
-    {current_function,{timer,sleep,1}} = process_info(TestPid, current_function),
+    {current_function, {timer, sleep, 1}} = process_info(TestPid, current_function),
 
     {ok, ComplexListTerm} = any_term_test_foil:lookup(list),
     {ok, ComplexListTerm} = foil:lookup(Table, list),

--- a/test/foil_tests.erl
+++ b/test/foil_tests.erl
@@ -75,8 +75,6 @@ foil_any_term_test()->
 
     ok = foil:load(Table),
 
-    ct:print("MODULE CODE: ~p~n", [code:load_file(Table)]),
-
     {ok, TestRef1} = any_term_test_foil:lookup(ref1),
     {ok, TestRef1} = foil:lookup(Table, ref1),
 

--- a/test/foil_tests.erl
+++ b/test/foil_tests.erl
@@ -39,3 +39,63 @@ foil_test() ->
     {error, module_not_found} = foil:delete(test),
 
     foil_app:stop().
+
+
+foil_any_term_test()->
+    error_logger:tty(false),
+
+    Table = any_term_test,
+
+    foil_app:start(),
+
+    ok = foil:new(Table),
+    TestPid = spawn(timer, sleep, [10000]),
+    TestRef1 = make_ref(),
+    TestRef2 = make_ref(),
+    RefList = [TestRef1, TestRef2],
+
+    ComplexListTerm = [make_ref(), make_ref(), {1,2,moo, {make_ref(), TestPid}}, "Hello"],
+    ComplexTupleTerm1 = {1, {ref1, make_ref()}, [TestPid]},
+    ComplexTupleTerm2 = {moo, boo, make_ref(), {1,2,3}, [5,6,7]},
+    PropList = [{ref1, make_ref()}, {ref2, make_ref()}, {ref3, make_ref()}],
+
+    ok = foil:insert(Table, ref1, TestRef1),
+    ok = foil:insert(Table, ref2, TestRef2),
+    ok = foil:insert(Table, ref_list, RefList),
+    ok = foil:insert(Table, pid, TestPid),
+    ok = foil:insert(Table, list, ComplexListTerm),
+    ok = foil:insert(Table, tuple1, ComplexTupleTerm1),
+    ok = foil:insert(Table, tuple2, ComplexTupleTerm2),
+    ok = foil:insert(Table, prop_list, PropList),
+
+    ok = foil:load(Table),
+
+    {ok, TestRef1} = any_term_test_foil:lookup(ref1),
+    {ok, TestRef1} = foil:lookup(Table, ref1),
+
+    {ok, TestRef2} = any_term_test_foil:lookup(ref2),
+    {ok, TestRef2} = foil:lookup(Table, ref2),
+
+    {ok, RefList} = any_term_test_foil:lookup(ref_list),
+    {ok, RefList} = foil:lookup(Table, ref_list),
+
+    {ok, TestPid} = any_term_test_foil:lookup(pid),
+    {ok, TestPid} = foil:lookup(Table, pid),
+    {current_function,{timer,sleep,1}} = process_info(TestPid, current_function),
+
+    {ok, ComplexListTerm} = any_term_test_foil:lookup(list),
+    {ok, ComplexListTerm} = foil:lookup(Table, list),
+
+    {ok, ComplexTupleTerm1} = any_term_test_foil:lookup(tuple1),
+    {ok, ComplexTupleTerm1} = foil:lookup(Table, tuple1),
+
+    {ok, ComplexTupleTerm2} = any_term_test_foil:lookup(tuple2),
+    {ok, ComplexTupleTerm2} = foil:lookup(Table, tuple2),
+
+    {ok, PropList} = any_term_test_foil:lookup(prop_list),
+    {ok, PropList} = foil:lookup(Table, prop_list),
+
+    ok = foil:delete(Table),
+    {error, module_not_found} = foil:delete(Table),
+
+    foil_app:stop().

--- a/test/foil_tests.erl
+++ b/test/foil_tests.erl
@@ -21,6 +21,8 @@ foil_test() ->
     ok = foil:insert(test, key2, [<<"foo">>, <<"bar">>]),
     ok = foil:insert(test, key3, {1, 1.234}),
     ok = foil:insert(test, key4, "test"),
+    ok = foil:insert(test, "key5", 5.5),
+    ok = foil:insert(test, 1.234, 2),
     {error, module_not_found} = foil:insert(test2, key2, value),
 
     ok = foil:delete(test, key4),
@@ -32,6 +34,8 @@ foil_test() ->
     {ok, value} = test_foil:lookup(key),
     {ok, [<<"foo">>, <<"bar">>]} = foil:lookup(test, key2),
     {ok, {1, 1.234}} = foil:lookup(test, key3),
+    {ok, 5.5} = foil:lookup(test, "key5"),
+    {ok, 2} = foil:lookup(test, 1.234),
     {error, module_not_found} = foil:lookup(test2, key),
     {error, key_not_found} = foil:lookup(test, key4),
 
@@ -64,17 +68,19 @@ foil_any_term_test()->
     ok = foil:insert(Table, ref_list, RefList),
     ok = foil:insert(Table, pid, TestPid),
     ok = foil:insert(Table, list, ComplexListTerm),
-    ok = foil:insert(Table, tuple1, ComplexTupleTerm1),
-    ok = foil:insert(Table, tuple2, ComplexTupleTerm2),
-    ok = foil:insert(Table, prop_list, PropList),
+    ok = foil:insert(Table, 1, ComplexTupleTerm1),
+    ok = foil:insert(Table, 2, ComplexTupleTerm2),
+    ok = foil:insert(Table, "prop_list", PropList),
 
     ok = foil:load(Table),
+
+    ct:print("MODULE CODE: ~p~n", [code:load_file(Table)]),
 
     {ok, TestRef1} = any_term_test_foil:lookup(ref1),
     {ok, TestRef1} = foil:lookup(Table, ref1),
 
-    {ok, TestRef2} = any_term_test_foil:lookup(ref2),
-    {ok, TestRef2} = foil:lookup(Table, ref2),
+%%    {ok, ref2} = any_term_test_foil:lookup(list_to_binary(term_to_binary(TestRef2))),
+%%    {ok, ref2} = foil:lookup(Table, TestRef2),
 
     {ok, RefList} = any_term_test_foil:lookup(ref_list),
     {ok, RefList} = foil:lookup(Table, ref_list),
@@ -86,14 +92,14 @@ foil_any_term_test()->
     {ok, ComplexListTerm} = any_term_test_foil:lookup(list),
     {ok, ComplexListTerm} = foil:lookup(Table, list),
 
-    {ok, ComplexTupleTerm1} = any_term_test_foil:lookup(tuple1),
-    {ok, ComplexTupleTerm1} = foil:lookup(Table, tuple1),
+    {ok, ComplexTupleTerm1} = any_term_test_foil:lookup(1),
+    {ok, ComplexTupleTerm1} = foil:lookup(Table, 1),
 
-    {ok, ComplexTupleTerm2} = any_term_test_foil:lookup(tuple2),
-    {ok, ComplexTupleTerm2} = foil:lookup(Table, tuple2),
+    {ok, ComplexTupleTerm2} = any_term_test_foil:lookup(2),
+    {ok, ComplexTupleTerm2} = foil:lookup(Table, 2),
 
-    {ok, PropList} = any_term_test_foil:lookup(prop_list),
-    {ok, PropList} = foil:lookup(Table, prop_list),
+    {ok, PropList} = any_term_test_foil:lookup("prop_list"),
+    {ok, PropList} = foil:lookup(Table, "prop_list"),
 
     ok = foil:delete(Table),
     {error, module_not_found} = foil:delete(Table),


### PR DESCRIPTION
Two functional modifications in this PR:

1. Added support for storing any value types that don't have `erl_syntax` equivalent, i.e. refs and pids in erlang serialized form.    This takes care of issue https://github.com/lpgauth/foil/issues/2 

2.  Replaced `foil_compiler:to_syntax` for tuple types with support for any complex term such as tuple, ref, pid, etc. with erlang serialization/deserialization considering it is done natively and should be faster than conversions of tuples to lists and/or list traversals.  

Added a unit test and modified README to reflect these changes. 